### PR TITLE
Update Conda environment definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kaggle.json
 .vscode/settings.json
+/data

--- a/environment.yml
+++ b/environment.yml
@@ -3,25 +3,28 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - librosa
-  - pandas
-  - jupyterlab
-  - seaborn
-  - matplotlib
-  - opendatasets
-  - pywavelets
-  - pyts
-  - optuna
-  - widgetsnbextension
   - ipywidgets
-  - pytorch
-  - pytorch::torchaudio
-  - shap
+  - jupyterlab
+  - librosa
   - lime
-  - pip
-  - requests
+  - matplotlib
   - natsort
+  - numpy
+  - opendatasets
+  - optuna
+  - pandas
+  - pip
+  - pyts
+  - pywavelets
+  - requests
+  - seaborn
+  - shap
+  - tqdm
+  - widgetsnbextension
   - pathlib
   - pip:
     - pyroomacoustics
     - python-sofa
+    - soundfile
+    - torch
+    - torchaudio


### PR DESCRIPTION
For easier reading, alphabetized all dependencies. Removed PyTorch from `conda` dependencies and added to `pip`, as PyTorch installation via `conda` is [no longer supported](https://github.com/pytorch/pytorch/issues/138506).